### PR TITLE
chore(README): add more "official loaders"

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ These loaders are officially maintained by their respective projects and are rec
 
 * [MDX loader](https://mdxjs.com/packages/node-loader/)
 * [SWC register](https://github.com/swc-project/swc-node/tree/master/packages/register#swc-noderegister)
+* [Aurelia loader](https://github.com/aurelia/loader-nodejs)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ node
 
 These loaders are officially maintained by their respective projects and are recommended (they're the most up-to-date and have the best support).
 
+* [Aurelia loader](https://github.com/aurelia/loader-nodejs)
 * [MDX loader](https://mdxjs.com/packages/node-loader/)
 * [SWC register](https://github.com/swc-project/swc-node/tree/master/packages/register#swc-noderegister)
-* [Aurelia loader](https://github.com/aurelia/loader-nodejs)


### PR DESCRIPTION
Aurelia is a frontend framework. And it's have it's own ESM loader. So let's mention it