### PR TITLE
feat(alias loader): make compatible with `module.registerHooks`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *.spec.*
 *.fixture.*
 fixture.*
+fixtures

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,6 +34,7 @@
 	// Language specific settings
 	"javascript": {
 		"formatter": {
+			"arrowParentheses": "always",
 			"semicolons": "always",
 			"quoteStyle": "single",
 			"trailingCommas": "all"

--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -7,6 +7,8 @@
 
 **Environments**: dev, test
 
+**Compatible APIs**: [`module.register`](https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options), [`module.registerHooks`](https://nodejs.org/api/module.html#moduleregisterhooksoptions)
+
 This loader facilitates TypeScript's [`paths`](https://www.typescriptlang.org/docs/handbook/modules/reference.html#paths), handling the (important) half of work TypeScript ignores. It looks for a `tsconfig.json` in the project root (the current working directory) and builds aliases from `compilerOptions.paths` if it exists. If your tsconfig lives in a different location, create a symlink to it from your project root.
 
 > [!CAUTION]

--- a/packages/alias/alias.mjs
+++ b/packages/alias/alias.mjs
@@ -19,13 +19,17 @@ function resolveAlias(specifier, ctx, next) {
 }
 export { resolveAlias as resolve };
 
-export async function resolveAliases(specifier, ctx, next) {
+export function resolveAliases(specifier, ctx, next) {
 	for (const [key, dest] of aliases) {
-		if (specifier === key) return next(dest, ctx);
-		if (specifier.startsWith(key)) return next(specifier.replace(key, dest));
+		if (specifier === key) {
+			return next(dest, ctx);
+		}
+		if (specifier.startsWith(key)) {
+			return next(specifier.replace(key, dest), ctx);
+		}
 	}
 
-	return next(specifier);
+	return next(specifier, ctx);
 }
 
 export function readConfigFile(filename) {

--- a/packages/alias/alias.spec.mjs
+++ b/packages/alias/alias.spec.mjs
@@ -46,65 +46,65 @@ describe('alias', () => {
 			({ resolve } = await import('./alias.mjs'));
 		});
 
-		await test('should de-alias a prefixed specifier', async () => {
+		await test('should de-alias a prefixed specifier', () => {
 			assert.equal(
-				(await resolve('…/test.mjs', {}, nextResolve)).url,
+				(resolve('…/test.mjs', {}, nextResolve)).url,
 				`${base}/src/test.mjs`,
 			);
 		});
 
-		await test('should de-alias a pointer (fully-qualified url) specifier', async () => {
-			assert.equal((await resolve('ENV', {}, nextResolve)).url, aliases.ENV[0]);
+		await test('should de-alias a pointer (fully-qualified url) specifier', () => {
+			assert.equal((resolve('ENV', {}, nextResolve)).url, aliases.ENV[0]);
 		});
 
-		await test('should de-alias a pointer (absolute path) specifier', async () => {
+		await test('should de-alias a pointer (absolute path) specifier', () => {
 			assert.equal(
-				(await resolve('VARS', {}, nextResolve)).url,
+				(resolve('VARS', {}, nextResolve)).url,
 				aliases.VARS[0],
 			);
 		});
 
-		await test('should maintain any suffixes on the prefixed specifier', async () => {
+		await test('should maintain any suffixes on the prefixed specifier', () => {
 			assert.equal(
-				(await resolve('…/test.mjs?foo', {}, nextResolve)).url,
+				(resolve('…/test.mjs?foo', {}, nextResolve)).url,
 				`${base}/src/test.mjs?foo`,
 			);
 			assert.equal(
-				(await resolve('…/test.mjs#bar', {}, nextResolve)).url,
+				(resolve('…/test.mjs#bar', {}, nextResolve)).url,
 				`${base}/src/test.mjs#bar`,
 			);
 			assert.equal(
-				(await resolve('…/test.mjs?foo#bar', {}, nextResolve)).url,
+				(resolve('…/test.mjs?foo#bar', {}, nextResolve)).url,
 				`${base}/src/test.mjs?foo#bar`,
 			);
 		});
 
-		await test('should maintain any suffixes on the pointer (fully-qualified url) specifier', async () => {
+		await test('should maintain any suffixes on the pointer (fully-qualified url) specifier', () => {
 			assert.equal(
-				(await resolve('ENV?foo', {}, nextResolve)).url,
+				(resolve('ENV?foo', {}, nextResolve)).url,
 				`${aliases.ENV[0]}?foo`,
 			);
 			assert.equal(
-				(await resolve('ENV#bar', {}, nextResolve)).url,
+				(resolve('ENV#bar', {}, nextResolve)).url,
 				`${aliases.ENV[0]}#bar`,
 			);
 			assert.equal(
-				(await resolve('ENV?foo#bar', {}, nextResolve)).url,
+				(resolve('ENV?foo#bar', {}, nextResolve)).url,
 				`${aliases.ENV[0]}?foo#bar`,
 			);
 		});
 
-		await test('should maintain any suffixes on the pointer (absolute path) specifier', async () => {
+		await test('should maintain any suffixes on the pointer (absolute path) specifier', () => {
 			assert.equal(
-				(await resolve('VARS?foo', {}, nextResolve)).url,
+				(resolve('VARS?foo', {}, nextResolve)).url,
 				`${aliases.VARS[0]}?foo`,
 			);
 			assert.equal(
-				(await resolve('VARS#bar', {}, nextResolve)).url,
+				(resolve('VARS#bar', {}, nextResolve)).url,
 				`${aliases.VARS[0]}#bar`,
 			);
 			assert.equal(
-				(await resolve('VARS?foo#bar', {}, nextResolve)).url,
+				(resolve('VARS?foo#bar', {}, nextResolve)).url,
 				`${aliases.VARS[0]}?foo#bar`,
 			);
 		});

--- a/packages/alias/alias.spec.mjs
+++ b/packages/alias/alias.spec.mjs
@@ -48,63 +48,60 @@ describe('alias', () => {
 
 		await test('should de-alias a prefixed specifier', () => {
 			assert.equal(
-				(resolve('…/test.mjs', {}, nextResolve)).url,
+				resolve('…/test.mjs', {}, nextResolve).url,
 				`${base}/src/test.mjs`,
 			);
 		});
 
 		await test('should de-alias a pointer (fully-qualified url) specifier', () => {
-			assert.equal((resolve('ENV', {}, nextResolve)).url, aliases.ENV[0]);
+			assert.equal(resolve('ENV', {}, nextResolve).url, aliases.ENV[0]);
 		});
 
 		await test('should de-alias a pointer (absolute path) specifier', () => {
-			assert.equal(
-				(resolve('VARS', {}, nextResolve)).url,
-				aliases.VARS[0],
-			);
+			assert.equal(resolve('VARS', {}, nextResolve).url, aliases.VARS[0]);
 		});
 
 		await test('should maintain any suffixes on the prefixed specifier', () => {
 			assert.equal(
-				(resolve('…/test.mjs?foo', {}, nextResolve)).url,
+				resolve('…/test.mjs?foo', {}, nextResolve).url,
 				`${base}/src/test.mjs?foo`,
 			);
 			assert.equal(
-				(resolve('…/test.mjs#bar', {}, nextResolve)).url,
+				resolve('…/test.mjs#bar', {}, nextResolve).url,
 				`${base}/src/test.mjs#bar`,
 			);
 			assert.equal(
-				(resolve('…/test.mjs?foo#bar', {}, nextResolve)).url,
+				resolve('…/test.mjs?foo#bar', {}, nextResolve).url,
 				`${base}/src/test.mjs?foo#bar`,
 			);
 		});
 
 		await test('should maintain any suffixes on the pointer (fully-qualified url) specifier', () => {
 			assert.equal(
-				(resolve('ENV?foo', {}, nextResolve)).url,
+				resolve('ENV?foo', {}, nextResolve).url,
 				`${aliases.ENV[0]}?foo`,
 			);
 			assert.equal(
-				(resolve('ENV#bar', {}, nextResolve)).url,
+				resolve('ENV#bar', {}, nextResolve).url,
 				`${aliases.ENV[0]}#bar`,
 			);
 			assert.equal(
-				(resolve('ENV?foo#bar', {}, nextResolve)).url,
+				resolve('ENV?foo#bar', {}, nextResolve).url,
 				`${aliases.ENV[0]}?foo#bar`,
 			);
 		});
 
 		await test('should maintain any suffixes on the pointer (absolute path) specifier', () => {
 			assert.equal(
-				(resolve('VARS?foo', {}, nextResolve)).url,
+				resolve('VARS?foo', {}, nextResolve).url,
 				`${aliases.VARS[0]}?foo`,
 			);
 			assert.equal(
-				(resolve('VARS#bar', {}, nextResolve)).url,
+				resolve('VARS#bar', {}, nextResolve).url,
 				`${aliases.VARS[0]}#bar`,
 			);
 			assert.equal(
-				(resolve('VARS?foo#bar', {}, nextResolve)).url,
+				resolve('VARS?foo#bar', {}, nextResolve).url,
 				`${aliases.VARS[0]}?foo#bar`,
 			);
 		});

--- a/packages/alias/alias.test.mjs
+++ b/packages/alias/alias.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { spawnPromisified } from '../../utils/spawn-promisified.mjs';
+
+import { message } from './fixtures/message.mjs';
+
+
+describe('alias (e2e', () => {
+	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
+	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));
+	const msgRgx = new RegExp(message);
+
+	it('should work with `--loader`', async () => {
+		const { code, stderr, stdout } = await spawnPromisified(execPath, [
+			'--no-warnings',
+			'--loader',
+			fileURLToPath(import.meta.resolve('./alias.mjs')),
+			e2eTest,
+		], { cwd });
+
+		assert.equal(stderr, '');
+		assert.match(stdout, msgRgx);
+		assert.equal(code, 0);
+	});
+
+	it('should work with `module.register`', async () => {
+		const { code, stderr, stdout } = await spawnPromisified(execPath, [
+			'--no-warnings',
+			'--import',
+			fileURLToPath(import.meta.resolve('./fixtures/register.mjs')),
+			e2eTest,
+		], { cwd });
+
+		assert.equal(stderr, '');
+		assert.match(stdout, msgRgx);
+		assert.equal(code, 0);
+	});
+
+	it('should work with `module.registerHooks`', async () => {
+		const { code, stderr, stdout } = await spawnPromisified(execPath, [
+			'--no-warnings',
+			'--import',
+			fileURLToPath(import.meta.resolve('./fixtures/register-hooks.mjs')),
+			e2eTest,
+		], { cwd });
+
+		assert.equal(stderr, '');
+		assert.match(stdout, msgRgx);
+		assert.equal(code, 0);
+	});
+});

--- a/packages/alias/alias.test.mjs
+++ b/packages/alias/alias.test.mjs
@@ -4,7 +4,9 @@ if (process.version.startsWith('v23')) {
 	const { describe, it } = await import('node:test');
 	const { fileURLToPath } = await import('node:url');
 
-	const { spawnPromisified } = await import('../../utils/spawn-promisified.mjs');
+	const { spawnPromisified } = await import(
+		'../../utils/spawn-promisified.mjs'
+	);
 
 	const { message } = await import('./fixtures/message.mjs');
 

--- a/packages/alias/alias.test.mjs
+++ b/packages/alias/alias.test.mjs
@@ -7,19 +7,22 @@ import { spawnPromisified } from '../../utils/spawn-promisified.mjs';
 
 import { message } from './fixtures/message.mjs';
 
-
 describe('alias (e2e', () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));
 	const msgRgx = new RegExp(message);
 
 	it('should work with `--loader`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(execPath, [
-			'--no-warnings',
-			'--loader',
-			fileURLToPath(import.meta.resolve('./alias.mjs')),
-			e2eTest,
-		], { cwd });
+		const { code, stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				'--loader',
+				fileURLToPath(import.meta.resolve('./alias.mjs')),
+				e2eTest,
+			],
+			{ cwd },
+		);
 
 		assert.equal(stderr, '');
 		assert.match(stdout, msgRgx);
@@ -27,12 +30,16 @@ describe('alias (e2e', () => {
 	});
 
 	it('should work with `module.register`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(execPath, [
-			'--no-warnings',
-			'--import',
-			fileURLToPath(import.meta.resolve('./fixtures/register.mjs')),
-			e2eTest,
-		], { cwd });
+		const { code, stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				'--import',
+				fileURLToPath(import.meta.resolve('./fixtures/register.mjs')),
+				e2eTest,
+			],
+			{ cwd },
+		);
 
 		assert.equal(stderr, '');
 		assert.match(stdout, msgRgx);
@@ -40,12 +47,16 @@ describe('alias (e2e', () => {
 	});
 
 	it('should work with `module.registerHooks`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(execPath, [
-			'--no-warnings',
-			'--import',
-			fileURLToPath(import.meta.resolve('./fixtures/register-hooks.mjs')),
-			e2eTest,
-		], { cwd });
+		const { code, stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				'--import',
+				fileURLToPath(import.meta.resolve('./fixtures/register-hooks.mjs')),
+				e2eTest,
+			],
+			{ cwd },
+		);
 
 		assert.equal(stderr, '');
 		assert.match(stdout, msgRgx);

--- a/packages/alias/alias.test.mjs
+++ b/packages/alias/alias.test.mjs
@@ -1,65 +1,67 @@
-import assert from 'node:assert/strict';
-import { execPath } from 'node:process';
-import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
+if (process.version.startsWith('v23')) {
+	const assert = await import('node:assert/strict');
+	const { execPath } = await import('node:process');
+	const { describe, it } = await import('node:test');
+	const { fileURLToPath } = await import('node:url');
 
-import { spawnPromisified } from '../../utils/spawn-promisified.mjs';
+	const { spawnPromisified } = await import('../../utils/spawn-promisified.mjs');
 
-import { message } from './fixtures/message.mjs';
+	const { message } = await import('./fixtures/message.mjs');
 
-describe('alias (e2e', () => {
-	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
-	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));
-	const msgRgx = new RegExp(message);
+	describe('alias (e2e', () => {
+		const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
+		const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));
+		const msgRgx = new RegExp(message);
 
-	it('should work with `--loader`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(
-			execPath,
-			[
-				'--no-warnings',
-				'--loader',
-				fileURLToPath(import.meta.resolve('./alias.mjs')),
-				e2eTest,
-			],
-			{ cwd },
-		);
+		it('should work with `--loader`', async () => {
+			const { code, stderr, stdout } = await spawnPromisified(
+				execPath,
+				[
+					'--no-warnings',
+					'--loader',
+					fileURLToPath(import.meta.resolve('./alias.mjs')),
+					e2eTest,
+				],
+				{ cwd },
+			);
 
-		assert.equal(stderr, '');
-		assert.match(stdout, msgRgx);
-		assert.equal(code, 0);
+			assert.equal(stderr, '');
+			assert.match(stdout, msgRgx);
+			assert.equal(code, 0);
+		});
+
+		it('should work with `module.register`', async () => {
+			const { code, stderr, stdout } = await spawnPromisified(
+				execPath,
+				[
+					'--no-warnings',
+					'--import',
+					fileURLToPath(import.meta.resolve('./fixtures/register.mjs')),
+					e2eTest,
+				],
+				{ cwd },
+			);
+
+			assert.equal(stderr, '');
+			assert.match(stdout, msgRgx);
+			assert.equal(code, 0);
+		});
+
+		it('should work with `module.registerHooks`', async () => {
+			const { code, stderr, stdout } = await spawnPromisified(
+				execPath,
+				[
+					'--no-warnings',
+					'--import',
+					fileURLToPath(import.meta.resolve('./fixtures/register-hooks.mjs')),
+					e2eTest,
+				],
+				{ cwd },
+			);
+
+			assert.equal(stderr, '');
+			assert.match(stdout, msgRgx);
+			assert.equal(code, 0);
+		});
 	});
-
-	it('should work with `module.register`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(
-			execPath,
-			[
-				'--no-warnings',
-				'--import',
-				fileURLToPath(import.meta.resolve('./fixtures/register.mjs')),
-				e2eTest,
-			],
-			{ cwd },
-		);
-
-		assert.equal(stderr, '');
-		assert.match(stdout, msgRgx);
-		assert.equal(code, 0);
-	});
-
-	it('should work with `module.registerHooks`', async () => {
-		const { code, stderr, stdout } = await spawnPromisified(
-			execPath,
-			[
-				'--no-warnings',
-				'--import',
-				fileURLToPath(import.meta.resolve('./fixtures/register-hooks.mjs')),
-				e2eTest,
-			],
-			{ cwd },
-		);
-
-		assert.equal(stderr, '');
-		assert.match(stdout, msgRgx);
-		assert.equal(code, 0);
-	});
-});
+}

--- a/packages/alias/fixtures/e2e.mjs
+++ b/packages/alias/fixtures/e2e.mjs
@@ -1,0 +1,3 @@
+import { message } from '@/message.mjs';
+
+console.log(message);

--- a/packages/alias/fixtures/message.mjs
+++ b/packages/alias/fixtures/message.mjs
@@ -1,0 +1,1 @@
+export const message = 'i was aliased';

--- a/packages/alias/fixtures/register-hooks.mjs
+++ b/packages/alias/fixtures/register-hooks.mjs
@@ -1,0 +1,5 @@
+import module from 'node:module';
+
+import * as aliasLoader from '../alias.mjs';
+
+module.registerHooks(aliasLoader);

--- a/packages/alias/fixtures/register.mjs
+++ b/packages/alias/fixtures/register.mjs
@@ -1,0 +1,3 @@
+import module from 'node:module';
+
+module.register('../alias.mjs', import.meta.url);

--- a/packages/alias/fixtures/tsconfig.json
+++ b/packages/alias/fixtures/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
+}

--- a/utils/spawn-promisified.mjs
+++ b/utils/spawn-promisified.mjs
@@ -1,0 +1,41 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * @param {...Parameters<typeof spawn>} args
+ */
+export function spawnPromisified(...args) {
+	let stderr = '';
+	let stdout = '';
+
+	const child = spawn(...args);
+	child.stderr?.setEncoding('utf8');
+	child.stderr?.on('data', (data) => {
+		stderr += data;
+	});
+	child.stdout?.setEncoding('utf8');
+	child.stdout?.on('data', (data) => {
+		stdout += data;
+	});
+
+	/**
+	 * @type {Promise<{ code: number | null, signal: NodeJS.Signals | null, stderr: string, stdout: string }>}
+	 */
+	return (new Promise((resolve, reject) => {
+		child.on('close', (code, signal) => {
+			resolve({
+				code,
+				signal,
+				stderr,
+				stdout,
+			});
+		});
+		child.on('error', (code, signal) => {
+			reject({
+				code,
+				signal,
+				stderr,
+				stdout,
+			});
+		});
+	}));
+}

--- a/utils/spawn-promisified.mjs
+++ b/utils/spawn-promisified.mjs
@@ -19,6 +19,7 @@ export function spawnPromisified(...args) {
 
 	/**
 	 * @type {Promise<{ code: number | null, signal: NodeJS.Signals | null, stderr: string, stdout: string }>}
+	 * biome-ignore format: https://github.com/biomejs/biome/issues/4799
 	 */
 	return (new Promise((resolve, reject) => {
 		child.on('close', (code, signal) => {


### PR DESCRIPTION
This now works:

```js
import module from 'node:module';
import * as aliasLoader from '@nodejs-loaders/alias';

module.registerHooks(aliasLoader);
```

as well as the current behaviour:

```js
import module from 'node:module';

module.register('@nodejs-loaders/alias', import.meta.url);
```

Note that not all of our loaders can be compatible with `module.registerHooks` because some are async.