### PR TITLE
ci: use `node --run`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           cache: 'npm'
       - name: npm clean install
         run: npm ci
-      - run: npm test
+      - run: node --run test
       - name: Publish coverage to Coveralls ${{ matrix.test_number }}
         uses: coverallsapp/github-action@v2
         with:


### PR DESCRIPTION
## Description

Use `--run` instead of `npm run`

## Related Issue

https://github.com/nodejs-loaders/nodejs-loaders/pull/92#discussion_r1908902158
