### PR TITLE
setup(workflow): move `type check` to run-once job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,13 @@ jobs:
         uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
         with:
           version: latest
+
+      - name: type check
+        run: npm run types:check
+
       - name: Run Biome
         run: biome ci .
+
       - name: Validate `package.json`s
         run: npm run pjson:check
 
@@ -61,11 +66,12 @@ jobs:
         with:
           node-version: ${{ matrix.node.version }}
           cache: 'npm'
+
       - name: npm clean install
         run: npm ci
-      - name: type check
-        run: npm run types:check
+
       - run: node --run test
+
       - name: Publish coverage to Coveralls ${{ matrix.test_number }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
             node-version-file: '.nvmrc'
+            cache: 'npm'
+
+      - name: npm clean install
+        run: npm ci
+
       - name: Setup Biome
         uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
         with:


### PR DESCRIPTION
Not sure how this got moved into the multi-node-version job.