### PR TITLE
release(deno-npm-prefix): bump version `1.0.1` → `1.1.0`

### DIFF
--- a/packages/deno-npm-prefix/package.json
+++ b/packages/deno-npm-prefix/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nodejs-loaders/deno-npm-prefix",
   "description": "Extend node to support a 'npm:' prefix via customization hooks.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "author": "Augustin Mauroy",
   "maintainers": [


### PR DESCRIPTION
## What's Changed

* chore(license): write it by @AugustinMauroy in https://github.com/nodejs-loaders/nodejs-loaders/pull/84
* feat(all): support registration via `--import` by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/113
* chore(all): restore original main entry-point file names by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/120

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v1.0.1@deno-npm-prefix...v1.1.0@deno-npm-prefix