### PR TITLE
release(alias): bumb version `1.1.0` → `2.0.0`

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "2.0.0",
   "name": "@nodejs-loaders/alias",
   "description": "Extend node to support TypeScript 'paths' via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed
* types:check to ci by @Ishan-Jadhav in https://github.com/nodejs-loaders/nodejs-loaders/pull/100
* feat(alias): replace deprecated `lodash.get` with optional chaining by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/119
* feat(all): support registration via `--import` by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/113
  * This is a breaking change for `alias` because the main entry-point now auto-registers its hooks via the async API (`node:module.register`); consumers who were registering its hooks via the sync API (`node:module.registerHooks`) will also inadvertently (and unknowingly) register those hooks via the async API due to merely importing the file. See [Usage with `module.registerHooks`](https://github.com/nodejs-loaders/nodejs-loaders?tab=readme-ov-file#usage-with-moduleregisterhooks) for how to avoid that.
* chore(all): restore original main entry-point file names by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/120

## New Contributors
* @Ishan-Jadhav made their first contribution in https://github.com/nodejs-loaders/nodejs-loaders/pull/100

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v1.1.1@alias...v2.0.0@alias