### PR TITLE
release(mismatched-format): bumb version `1.0.1` → `1.1.0`

### DIFF
--- a/packages/mismatched-format/package.json
+++ b/packages/mismatched-format/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.1.0",
   "name": "@nodejs-loaders/mismatched-format",
   "description": "Extend node to support misconfigured module formats via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* types:check to ci by @Ishan-Jadhav in https://github.com/nodejs-loaders/nodejs-loaders/pull/100
* chore(license): write it by @AugustinMauroy in https://github.com/nodejs-loaders/nodejs-loaders/pull/84
* feat(all): support registration via `--import` by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/113
* chore(all): restore original main entry-point file names by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/120

## New Contributors
* @Ishan-Jadhav made their first contribution in https://github.com/nodejs-loaders/nodejs-loaders/pull/100

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v1.0.1@mismatched-format...v1.1.0@mismatched-format