### PR TITLE
release(alias): bumb version `2.0.0` → `2.0.1`

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.0.1",
   "name": "@nodejs-loaders/alias",
   "description": "Extend node to support TypeScript 'paths' via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* fix(alias): correct hook types by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/156
* fix(alias): support `tsconfig` as JSON5 (trailing commas, comments) by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/155

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v2.0.0@alias...v2.0.1@alias