### PR TITLE
doc(media): add usage section with extension customization

### DIFF
--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -39,6 +39,27 @@ Images:
 * `.webp`
 </details>
 
+## Usage
+
+Simple usage:
+
+```ts
+import { register } from 'node:module';
+
+register('@nodejs-loaders/media', import.meta.url);
+```
+
+Customize extensions:
+
+```ts
+import { register } from 'node:module';
+import { exts } from '@nodejs-loaders/media/media.loader.mjs';
+
+exts.add('.abc');
+exts.add('.xyz');
+register('@nodejs-loaders/media', import.meta.url);
+```
+
 ## Alternatives
 
 * [`esm-loader-images`](https://github.com/brev/esm-loaders/tree/main/packages/esm-loader-images#readme) - This alternative loader just supports images.


### PR DESCRIPTION
## Description

<!--
	Thank you for your contribution! Please provide details for what and why this PR is needed.

	If it is a bug-fix, please cover the reproduction(s) with unit test(s).
-->

Added a "Usage" section to the `@nodejs-loaders/media` readme, including a section on how to customize the file extensions, as mentioned here:

- https://github.com/nodejs-loaders/nodejs-loaders/issues/166#issuecomment-2694420265

## Related Issue

- #166

## Checklist

<!--
	You can check the items by adding an `x` between the brackets, like this: - [x]
-->

<!--
	See https://github.com/nodejs-loaders/nodejs-loaders/blob/main/CONTRIBUTING.md for tips opening a PR, like checking for lint.
-->

The following have been added/updated as appropriate:

- [x] Documentation, including README(s) and code comments.
- [ ] Test-cases.

<!-- Thank you for your contribution to the project. Please provide the details of your contribution and ensure that you have checked the items in the checklist. -->
