### PR TITLE
fix(json5): set type for `resolveJSON5` (`ResolveHook`)

### DIFF
--- a/packages/json5/json5.loader.mjs
+++ b/packages/json5/json5.loader.mjs
@@ -3,6 +3,9 @@ import JSON5 from 'json5';
 
 /** @typedef {import('../types.d.ts').FileURL} FileURL */
 
+/**
+ * @type {import('node:module').ResolveHook}
+ */
 async function resolveJSON5(specifier, ctx, nextResolve) {
 	const nextResult = await nextResolve(specifier);
 	const ext = getFilenameExt(/** @type {FileURL} */ (nextResult.url));


### PR DESCRIPTION
We should probably have a test for these so it doesn't get missed (like it did here) 🤔