### PR TITLE
fix(tsx): use source maps

### DIFF
--- a/packages/tsx/find-esbuild-config.mjs
+++ b/packages/tsx/find-esbuild-config.mjs
@@ -50,10 +50,14 @@ export function findEsbuildConfig(target, parentURL = target) {
 const PJSON_FNAME = 'package.json';
 const CONFIG_FNAME = 'esbuild.config.mjs';
 
+/**
+ * @type {ESBuildOptions}
+ */
 export const defaults = {
 	jsx: 'automatic',
 	jsxDev: true,
 	jsxFactory: 'React.createElement',
 	loader: 'tsx',
 	minify: true,
+	sourcemap: true,
 };

--- a/packages/tsx/tsx.loader.mjs
+++ b/packages/tsx/tsx.loader.mjs
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { cwd } from 'node:process';
+import { cwd, setSourceMapsEnabled, sourceMapsEnabled } from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 import { transform } from 'esbuild';

--- a/packages/tsx/tsx.loader.mjs
+++ b/packages/tsx/tsx.loader.mjs
@@ -71,10 +71,10 @@ async function loadTSX(url, ctx, nextLoad) {
 		rawSource = `import * as React from 'react';\n${rawSource}`;
 	}
 
-	const { code: source, warnings } = await transform(
-		rawSource,
-		esbuildConfig,
-	).catch(({ errors }) => {
+	const { code: source, warnings } = await transform(rawSource, {
+		sourcefile: url,
+		...esbuildConfig,
+	}).catch(({ errors }) => {
 		for (const {
 			location: { column, line, lineText },
 			text,

--- a/packages/tsx/tsx.spec.mjs
+++ b/packages/tsx/tsx.spec.mjs
@@ -112,7 +112,7 @@ describe('JSX & TypeScript loader', { concurrency: true, skip }, () => {
 			const result = await load(fileUrl, { format: 'jsx' }, nextLoad);
 
 			assert.equal(result.format, 'module');
-			assert.equal(result.source, transpiled);
+			assert.equal(result.source, transpiled.replaceAll("<stdin>", fileUrl));
 		});
 
 		it('should transpile TSX', async () => {
@@ -120,7 +120,7 @@ describe('JSX & TypeScript loader', { concurrency: true, skip }, () => {
 			const result = await load(fileUrl, { format: 'tsx' }, nextLoad);
 
 			assert.equal(result.format, 'module');
-			assert.equal(result.source, transpiled);
+			assert.equal(result.source, transpiled.replaceAll("<stdin>", fileUrl));
 		});
 
 		it('should log transpile errors', async () => {

--- a/test/run-benchs.mjs
+++ b/test/run-benchs.mjs
@@ -28,10 +28,13 @@ if (w) {
 	w = w.replace('packages/', '');
 }
 
-const files = globSync(`packages/${w}**/**.bench.{js,mjs}`);
+const glob = `packages/${w}**/**.bench.{js,mjs}`;
+const files = globSync(glob);
 
 if (files.length === 0) {
-	throw new Error(`${styleText(['red'], '✕')} No benchmarks found`);
+	throw new Error(
+		`${styleText(['red'], '✕')} No benchmarks found\nFor blobs: ${glob}`,
+	);
 }
 
 console.log(`${styleText(['green'], '✓')} Found ${files.length} benchmarks`);


### PR DESCRIPTION
## Description

Adding support of source map + filename allow us to have real representation of line/collum in stack trace/test runner report.
