### PR TITLE
release(media): bump version `1.2.0` → `1.3.0`

### DIFF
--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "name": "@nodejs-loaders/media",
   "description": "Extend node to support media imports via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* feat(media): add `.epdb` and `.pdf` to default list of file extensions by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/174

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v1.2.0@media...v1.3.0@media