### PR TITLE
test(all): parallelise case execution

### DIFF
--- a/packages/alias/alias.spec.mjs
+++ b/packages/alias/alias.spec.mjs
@@ -3,7 +3,7 @@ import { before, describe, mock, test } from 'node:test';
 
 import { nextResolve } from '../../fixtures/nextResolve.fixture.mjs';
 
-describe('alias', () => {
+describe('alias', { concurrency: true }, () => {
 	/** @type {MockFunctionContext<NoOpFunction>} */
 	let mock_readFileSync;
 	const base = 'file://';

--- a/packages/alias/alias.test.mjs
+++ b/packages/alias/alias.test.mjs
@@ -8,7 +8,7 @@ import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
 import { message } from './fixtures/message.mjs';
 
-describe('alias (e2e)', () => {
+describe('alias (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const encoding = 'utf8';
 	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));

--- a/packages/css-module/css-module.test.mjs
+++ b/packages/css-module/css-module.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
-describe('css-module (e2e)', () => {
+describe('css-module (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const encoding = 'utf8';
 	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));

--- a/packages/deno-npm-prefix/deno-npm-prefix.spec.mjs
+++ b/packages/deno-npm-prefix/deno-npm-prefix.spec.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { resolve } from './deno-npm-prefix.loader.mjs';
 
-describe('deno-npm-prefix', () => {
+describe('deno-npm-prefix', { concurrency: true }, () => {
 	describe('resolve', () => {
 		it('should remove "npm:" prefix from specifier', async () => {
 			const specifier = 'npm:lodash';

--- a/packages/deno-npm-prefix/deno-npm-prefix.test.mjs
+++ b/packages/deno-npm-prefix/deno-npm-prefix.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
-describe('deno-npm-prefix (e2e)', () => {
+describe('deno-npm-prefix (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const encoding = 'utf8';
 	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));

--- a/packages/json5/json5.test.mjs
+++ b/packages/json5/json5.test.mjs
@@ -8,7 +8,7 @@ import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 const encoding = 'utf8';
 const env = { NO_COLOR: true };
 
-describe('json5 (e2e)', () => {
+describe('json5 (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const e2eTest = fileURLToPath(
 		import.meta.resolve('./fixtures/e2e-json5.mjs'),

--- a/packages/jsonc/jsonc.test.mjs
+++ b/packages/jsonc/jsonc.test.mjs
@@ -8,7 +8,7 @@ import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 const encoding = 'utf8';
 const env = { NO_COLOR: true };
 
-describe('jsonc (e2e)', () => {
+describe('jsonc (e2e)', { concurrency: true }, () => {
 	describe('json', () => {
 		const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 		const e2eTest = fileURLToPath(

--- a/packages/media/media.test.mjs
+++ b/packages/media/media.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
-describe('media (e2e)', () => {
+describe('media (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const encoding = 'utf8';
 	const e2eTest = fileURLToPath(import.meta.resolve('./fixtures/e2e.mjs'));

--- a/packages/mismatched-format/contains-cjs.spec.mjs
+++ b/packages/mismatched-format/contains-cjs.spec.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { containsCJS } from './contains-cjs.mjs';
 
-describe('Contains CJS()', () => {
+describe('Contains CJS()', { concurrency: true }, () => {
 	describe('exports', () => {
 		const matches = [
 			'exports.foo =',

--- a/packages/mismatched-format/mismatched-format.loader.mjs
+++ b/packages/mismatched-format/mismatched-format.loader.mjs
@@ -20,17 +20,17 @@ async function loadMismatchedFormat(url, ctx, next) {
 			// the fact that this function is async for this to be used in `module.register`
 			// @ts-ignore - so then is needed and `next()` can't be sync
 			.then((result) => {
-				if (containsCJS('' + result.source)) {
-					throw new Error('CommonJS');
-				}
+				if (containsCJS('' + result.source)) throw new Error('CommonJS');
 
 				return result;
 			})
 			.catch(async (err) => {
 				if (
-					(err?.message.includes('require') &&
-						err?.message.includes('import')) ||
-					err?.message.includes('CommonJS')
+					(
+						err?.message.includes('require')
+						&& err?.message.includes('import')
+					)
+					|| err?.message.includes('CommonJS')
 				) {
 					return { format: 'commonjs' };
 				}

--- a/packages/mismatched-format/mismatched-format.spec.mjs
+++ b/packages/mismatched-format/mismatched-format.spec.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import { before, describe, it, mock } from 'node:test';
 
-describe('Mismatched format loader (unit)', () => {
+// `concurrency` creates a race condition in the test setup. the perf diff is ~nonexistent
+describe('Mismatched format loader (unit)', { concurrency: false }, () => {
 	/** @type {import('./mismatched-format.loader.mjs').load} */
 	let load;
 	/** @type {MockFunctionContext<NoOpFunction>} */

--- a/packages/mismatched-format/mismatched-format.test.mjs
+++ b/packages/mismatched-format/mismatched-format.test.mjs
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test';
 import { load } from './mismatched-format.loader.mjs';
 import { nextLoad } from '../../fixtures/nextLoad.fixture.mjs';
 
-describe('Mismatched format loader (e2e)', () => {
+describe('Mismatched format loader (e2e)', { concurrency: true }, () => {
 	describe('correctly identify the containing CJS as CJS, despite "type": "module"', () => {
 		it('should handle `require()`', async () => {
 			const result = await load(

--- a/packages/parse-filename/parse-filename.spec.mjs
+++ b/packages/parse-filename/parse-filename.spec.mjs
@@ -7,7 +7,7 @@ import {
 	stripExtras,
 } from './parse-filename.mjs';
 
-describe('parse-filename', () => {
+describe('parse-filename', { concurrency: true }, () => {
 	const base = 'foo';
 	const ext = '.ext';
 

--- a/packages/svelte/svelte.test.mjs
+++ b/packages/svelte/svelte.test.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
-describe('svelte (e2e)', () => {
+describe('svelte (e2e)', { concurrency: true }, () => {
 	const cwd = fileURLToPath(import.meta.resolve('./fixtures'));
 	const encoding = 'utf8';
 	const env = {

--- a/packages/tsx/tsx.test.mjs
+++ b/packages/tsx/tsx.test.mjs
@@ -7,7 +7,7 @@ import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
 const skip = +process.version.slice(1, 3) < 23;
 
-describe('JSX & TypeScript loader (e2e)', { skip }, () => {
+describe('JSX & TypeScript loader (e2e)', { concurrency: true }, { skip }, () => {
 	/**
 	 * If react isn't found, the transpilation has happened. If there is another error, the
 	 * transpilation failed (kind of hypothetical)

--- a/packages/tsx/tsx.test.mjs
+++ b/packages/tsx/tsx.test.mjs
@@ -7,7 +7,7 @@ import { spawnPromisified } from '../../test/spawn-promisified.mjs';
 
 const skip = +process.version.slice(1, 3) < 23;
 
-describe('JSX & TypeScript loader (e2e)', { concurrency: true }, { skip }, () => {
+describe('JSX & TypeScript loader (e2e)', { concurrency: true, skip }, () => {
 	/**
 	 * If react isn't found, the transpilation has happened. If there is another error, the
 	 * transpilation failed (kind of hypothetical)


### PR DESCRIPTION
This reduces total test execution time by about a third.