### PR TITLE
fix(alias): unresolvable specifier should not fail on internal checks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -67,12 +67,12 @@
 				"sibling",
 				"index",
 				"unknown",
-		   ],
-		   "newlines-between": "always",
-		   "alphabetize": {
+			],
+			"newlines-between": "always",
+			"alphabetize": {
 				"order": "asc",
 				"caseInsensitive": false,
-		   },
+			},
 		}],
 		"typescript/ban-types": "off",
 		"typescript/no-import-type-side-effects": "error",
@@ -92,6 +92,7 @@
 				"*.test.jsx",
 			],
 			"rules": {
+				"max-classes-per-file": "off",
 				"max-depth": "off",
 				"max-lines-per-function": "off",
 				"max-nested-callbacks": "off",

--- a/packages/alias/alias.loader.mjs
+++ b/packages/alias/alias.loader.mjs
@@ -62,7 +62,8 @@ export function resolveAliases(specifier, { aliases }, next) {
 			catch (err) { if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err }
 
 			// Need the promise path for the async path (module.register)
-			if (resolved instanceof Promise) {
+			// Eff you typescript
+			if (resolved && 'catch' in resolved && typeof resolved.catch === 'function') {
 				return resolved.catch((err) => {
 					if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err;
 

--- a/packages/alias/alias.loader.mjs
+++ b/packages/alias/alias.loader.mjs
@@ -62,7 +62,7 @@ export function resolveAliases(specifier, { aliases }, next) {
 			catch (err) { if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err }
 
 			// Need the promise path for the async path (module.register)
-			if ('catch' in resolved && typeof resolved?.catch === 'function') {
+			if (resolved instanceof Promise) {
 				return resolved.catch((err) => {
 					if (err.code !== 'ERR_MODULE_NOT_FOUND') throw err;
 

--- a/packages/alias/alias.spec.mjs
+++ b/packages/alias/alias.spec.mjs
@@ -16,6 +16,11 @@ describe('alias', { concurrency: true }, () => {
 
 	class ENOENT extends Error {
 		code = 'ENOENT';
+		name = 'ENOENT';
+	}
+	class ERR_MODULE_NOT_FOUND extends Error {
+		code = 'ERR_MODULE_NOT_FOUND';
+		name = 'ERR_MODULE_NOT_FOUND';
 	}
 
 	before(async () => {
@@ -103,6 +108,34 @@ describe('alias', { concurrency: true }, () => {
 				resolve('VARS?foo#bar', ctx, nextResolve).url,
 				`${aliases.VARS[0]}?foo#bar`,
 			);
+		});
+
+		describe('that are unresolvable', () => {
+			test('(async) should not fail internally', () => {
+				async function nextUnresolveable(s) {
+					throw new ERR_MODULE_NOT_FOUND(s);
+				}
+
+				const specifier = '…/noexist.mjs';
+
+				assert.rejects(
+					() => resolve(specifier, ctx, nextUnresolveable),
+					new RegExp(specifier),
+				);
+			});
+
+			test('(sync) should not fail internally', () => {
+				function nextUnresolveable(s) {
+					throw new ERR_MODULE_NOT_FOUND(s);
+				}
+
+				const specifier = '…/noexist.mjs';
+
+				assert.throws(
+					() => resolve(specifier, ctx, nextUnresolveable),
+					new RegExp(specifier),
+				);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Description

A bug introduced in alias@2.1.0 where the is promise-like check recommended by `tsc` would fail when aliased specifier did not resolve (and alias is checking whether it's part of a synchronous or asynchronous chain).
