### PR TITLE
release(alias): bump version `2.1.0` → `2.1.1`

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "name": "@nodejs-loaders/alias",
   "description": "Extend node to support TypeScript 'paths' via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* doc(alias): fix bad markdown in readme by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/198
* fix(alias): unresolvable specifier should not fail on internal checks by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/199

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v2.1.0@alias...v2.1.1@alias