### PR TITLE
release(alias): bump version `2.1.1` → `2.1.2`

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "name": "@nodejs-loaders/alias",
   "description": "Extend node to support TypeScript 'paths' via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* fix(alias): subpath import key erroneously flagged as directory by @JakobJingleheimer in https://github.com/nodejs-loaders/nodejs-loaders/pull/211
* dep(node): officially support node 24.x (add to CI) by @AugustinMauroy in https://github.com/nodejs-loaders/nodejs-loaders/pull/210

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v2.1.1@alias...v2.1.2@alias