### PR TITLE
release(tsx): bump version `1.1.1` → `1.1.2`

### DIFF
--- a/packages/tsx/package.json
+++ b/packages/tsx/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "@nodejs-loaders/tsx",
   "description": "Extend node to support JSX & TSX via customization hooks.",
   "type": "module",


### PR DESCRIPTION
## What's Changed

* dep(node): support node v24.x by @AugustinMauroy in https://github.com/nodejs-loaders/nodejs-loaders/pull/210
* fix(windows): allow for windows support by @avivkeller in https://github.com/nodejs-loaders/nodejs-loaders/pull/189

## New Contributors
* @avivkeller made their first contribution in https://github.com/nodejs-loaders/nodejs-loaders/pull/189

**Full Changelog**: https://github.com/nodejs-loaders/nodejs-loaders/compare/v1.1.1@tsx...v1.1.2@tsx