### PR TITLE
test(tsx): validate preact and solid jsx runtimes

### DIFF
--- a/packages/tsx/fixtures/with-preact/esbuild.config.mjs
+++ b/packages/tsx/fixtures/with-preact/esbuild.config.mjs
@@ -1,0 +1,5 @@
+// oxlint-disable-next-line no-anonymous-default-export
+export default {
+	jsxImportSource: 'preact',
+	minify: false,
+};

--- a/packages/tsx/fixtures/with-preact/main.jsx
+++ b/packages/tsx/fixtures/with-preact/main.jsx
@@ -1,0 +1,6 @@
+import { Wrapper } from './wrapper.jsx';
+
+export function Greet({ name }) {
+	return (<h1>Hello <Wrapper>{name}</Wrapper></h1>);
+}
+Greet.displayName = 'Greet';

--- a/packages/tsx/fixtures/with-preact/main.tsx
+++ b/packages/tsx/fixtures/with-preact/main.tsx
@@ -1,0 +1,6 @@
+import { Wrapper } from './wrapper.jsx';
+
+export function Greet({ name }: { name: string }) {
+	return (<h1>Hello <Wrapper>{name}</Wrapper></h1>);
+}
+Greet.displayName = 'Greet';

--- a/packages/tsx/fixtures/with-preact/package.json
+++ b/packages/tsx/fixtures/with-preact/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "e2e-tsx-preact",
+  "main": "./main.jsx",
+  "dependencies": {
+    "@nodejs-loaders/tsx": "*"
+  }
+}

--- a/packages/tsx/fixtures/with-preact/register-hooks.mjs
+++ b/packages/tsx/fixtures/with-preact/register-hooks.mjs
@@ -1,0 +1,5 @@
+import module from 'node:module';
+
+import * as tsxLoader from '../../tsx.loader.mjs';
+
+module.registerHooks(tsxLoader);

--- a/packages/tsx/fixtures/with-preact/register.mjs
+++ b/packages/tsx/fixtures/with-preact/register.mjs
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('@nodejs-loaders/tsx', pathToFileURL('./'));

--- a/packages/tsx/fixtures/with-preact/wrapper.jsx
+++ b/packages/tsx/fixtures/with-preact/wrapper.jsx
@@ -1,0 +1,1 @@
+export const Wrapper = ({ children: content }) => (<span>{content}</span>);

--- a/packages/tsx/fixtures/with-solid/esbuild.config.mjs
+++ b/packages/tsx/fixtures/with-solid/esbuild.config.mjs
@@ -1,0 +1,5 @@
+// oxlint-disable-next-line no-anonymous-default-export
+export default {
+	jsxImportSource: 'solid-js',
+	minify: false,
+};

--- a/packages/tsx/fixtures/with-solid/main.jsx
+++ b/packages/tsx/fixtures/with-solid/main.jsx
@@ -1,0 +1,6 @@
+import { Wrapper } from './wrapper.jsx';
+
+export function Greet({ name }) {
+	return (<h1>Hello <Wrapper>{name}</Wrapper></h1>);
+}
+Greet.displayName = 'Greet';

--- a/packages/tsx/fixtures/with-solid/main.tsx
+++ b/packages/tsx/fixtures/with-solid/main.tsx
@@ -1,0 +1,6 @@
+import { Wrapper } from './wrapper.jsx';
+
+export function Greet({ name }: { name: string }) {
+	return (<h1>Hello <Wrapper>{name}</Wrapper></h1>);
+}
+Greet.displayName = 'Greet';

--- a/packages/tsx/fixtures/with-solid/package.json
+++ b/packages/tsx/fixtures/with-solid/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "e2e-tsx-solid",
+  "main": "./main.jsx",
+  "dependencies": {
+    "@nodejs-loaders/tsx": "*"
+  }
+}

--- a/packages/tsx/fixtures/with-solid/register-hooks.mjs
+++ b/packages/tsx/fixtures/with-solid/register-hooks.mjs
@@ -1,0 +1,5 @@
+import module from 'node:module';
+
+import * as tsxLoader from '../../tsx.loader.mjs';
+
+module.registerHooks(tsxLoader);

--- a/packages/tsx/fixtures/with-solid/register.mjs
+++ b/packages/tsx/fixtures/with-solid/register.mjs
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('@nodejs-loaders/tsx', pathToFileURL('./'));

--- a/packages/tsx/fixtures/with-solid/wrapper.jsx
+++ b/packages/tsx/fixtures/with-solid/wrapper.jsx
@@ -1,0 +1,1 @@
+export const Wrapper = ({ children: content }) => (<span>{content}</span>);

--- a/packages/tsx/tsx.spec.mjs
+++ b/packages/tsx/tsx.spec.mjs
@@ -11,18 +11,65 @@ const jsxExts = new Set(['.jsx']);
 
 const tsxExts = new Set(['.mts', '.ts', '.tsx']);
 
+function getConfigKey(url) {
+	const target = `${url}`;
+
+	if (target.includes('/fixtures/with-preact/')) return 'preact';
+	if (target.includes('/fixtures/with-solid/')) return 'solid';
+
+	return 'react';
+}
+
+function getTranspiled(runtime) {
+	return [
+		`import { jsxDEV } from "${runtime}/jsx-dev-runtime";`,
+		'import { Wrapper } from "./wrapper.jsx";',
+		'export function Greet({ name }) {',
+		'  return /* @__PURE__ */ jsxDEV("h1", { children: [',
+		'    "Hello ",',
+		'    /* @__PURE__ */ jsxDEV(Wrapper, { children: name }, void 0, false, {',
+		'      fileName: "<stdin>",',
+		'      lineNumber: 4,',
+		'      columnNumber: 20',
+		'    }, this)',
+		'  ] }, void 0, true, {',
+		'    fileName: "<stdin>",',
+		'    lineNumber: 4,',
+		'    columnNumber: 10',
+		'  }, this);',
+		'}',
+		'Greet.displayName = "Greet";',
+		'', //EoF
+	].join('\n');
+}
+
 describe('JSX & TypeScript loader', { concurrency: true, skip }, () => {
 	let load;
 	let resolve;
 
 	before(async () => {
 		// This is necessary because now `load` depends on `resolve` having run.
-		const esbuildConfig = {
-			...(await import('./find-esbuild-config.mjs')).defaults,
-			...(await import('./fixtures/with-config/esbuild.config.mjs')).default,
+		const defaults = (await import('./find-esbuild-config.mjs')).defaults;
+		const reactConfig = (await import('./fixtures/with-config/esbuild.config.mjs')).default;
+		const preactConfig = (await import('./fixtures/with-preact/esbuild.config.mjs')).default;
+		const solidConfig = (await import('./fixtures/with-solid/esbuild.config.mjs')).default;
+
+		const esbuildConfigs = {
+			preact: {
+				...defaults,
+				...preactConfig,
+			},
+			react: {
+				...defaults,
+				...reactConfig,
+			},
+			solid: {
+				...defaults,
+				...solidConfig,
+			},
 		};
 		mock.module('./find-esbuild-config.mjs', {
-			namedExports: { findEsbuildConfig: () => esbuildConfig },
+			namedExports: { findEsbuildConfig: (target) => esbuildConfigs[getConfigKey(target)] },
 		});
 
 		({ load, resolve } = await import('./tsx.loader.mjs'));
@@ -124,32 +171,13 @@ describe('JSX & TypeScript loader', { concurrency: true, skip }, () => {
 			});
 		});
 
-		// This verifies that esbuild.config.mjs is being loaded correctly because the one in this repo
-		// disables minification, but the loader's default config enables it.
-		const transpiled = [
-			'import { jsxDEV } from "react/jsx-dev-runtime";',
-			'import { Wrapper } from "./wrapper.jsx";',
-			'export function Greet({ name }) {',
-			'  return /* @__PURE__ */ jsxDEV("h1", { children: [',
-			'    "Hello ",',
-			'    /* @__PURE__ */ jsxDEV(Wrapper, { children: name }, void 0, false, {',
-			'      fileName: "<stdin>",',
-			'      lineNumber: 4,',
-			'      columnNumber: 20',
-			'    }, this)',
-			'  ] }, void 0, true, {',
-			'    fileName: "<stdin>",',
-			'    lineNumber: 4,',
-			'    columnNumber: 10',
-			'  }, this);',
-			'}',
-			'Greet.displayName = "Greet";',
-			'', //EoF
-		].join('\n');
-
 		it('should transpile JSX', () => {
 			const fileUrl = import.meta.resolve('./fixtures/with-config/main.jsx');
 			const result = load(fileUrl, { format: 'jsx' }, nextLoadSync);
+
+			// This verifies that esbuild.config.mjs is being loaded correctly because the one in this repo
+			// disables minification, but the loader's default config enables it.
+			const transpiled = getTranspiled('react');
 
 			assert.equal(result.format, 'module');
 			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));
@@ -158,6 +186,43 @@ describe('JSX & TypeScript loader', { concurrency: true, skip }, () => {
 		it('should transpile TSX', () => {
 			const fileUrl = import.meta.resolve('./fixtures/with-config/main.tsx');
 			const result = load(fileUrl, { format: 'tsx' }, nextLoadSync);
+			const transpiled = getTranspiled('react');
+
+			assert.equal(result.format, 'module');
+			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));
+		});
+
+		it('should transpile JSX with Preact', () => {
+			const fileUrl = import.meta.resolve('./fixtures/with-preact/main.jsx');
+			const result = load(fileUrl, { format: 'jsx' }, nextLoadSync);
+			const transpiled = getTranspiled('preact');
+
+			assert.equal(result.format, 'module');
+			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));
+		});
+
+		it('should transpile TSX with Preact', () => {
+			const fileUrl = import.meta.resolve('./fixtures/with-preact/main.tsx');
+			const result = load(fileUrl, { format: 'tsx' }, nextLoadSync);
+			const transpiled = getTranspiled('preact');
+
+			assert.equal(result.format, 'module');
+			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));
+		});
+
+		it('should transpile JSX with SolidJS', () => {
+			const fileUrl = import.meta.resolve('./fixtures/with-solid/main.jsx');
+			const result = load(fileUrl, { format: 'jsx' }, nextLoadSync);
+			const transpiled = getTranspiled('solid-js');
+
+			assert.equal(result.format, 'module');
+			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));
+		});
+
+		it('should transpile TSX with SolidJS', () => {
+			const fileUrl = import.meta.resolve('./fixtures/with-solid/main.tsx');
+			const result = load(fileUrl, { format: 'tsx' }, nextLoadSync);
+			const transpiled = getTranspiled('solid-js');
 
 			assert.equal(result.format, 'module');
 			assert.equal(result.source, transpiled.replaceAll('<stdin>', fileUrl));

--- a/packages/tsx/tsx.test.mjs
+++ b/packages/tsx/tsx.test.mjs
@@ -9,10 +9,10 @@ const skip = +process.version.slice(1, 3) < 23;
 
 describe('JSX & TypeScript loader (e2e)', { concurrency: true, skip }, () => {
 	/**
-	 * If react isn't found, the transpilation has happened. If there is another error, the
+	 * If the runtime package isn't found, the transpilation has happened. If there is another error, the
 	 * transpilation failed (kind of hypothetical)
 	 */
-	it('--loader should load a TSX file but fail because of missing react package', async () => {
+	it('--loader should load a React TSX file but fail because of missing react package', async () => {
 		const cwd = path.join(import.meta.dirname, 'fixtures/with-config');
 		const { stderr, stdout } = await spawnPromisified(
 			execPath,
@@ -31,7 +31,7 @@ describe('JSX & TypeScript loader (e2e)', { concurrency: true, skip }, () => {
 		assert.equal(stdout, '');
 	});
 
-	it('--import should load a TSX file but fail because of missing react package', async () => {
+	it('--import should load a React JSX file but fail because of missing react package', async () => {
 		const cwd = path.join(import.meta.dirname, 'fixtures/with-config');
 		const { stderr, stdout } = await spawnPromisified(
 			execPath,
@@ -46,6 +46,80 @@ describe('JSX & TypeScript loader (e2e)', { concurrency: true, skip }, () => {
 		);
 
 		assert.match(stderr, /Cannot find package 'react' imported from/);
+		assert.equal(stdout, '');
+	});
+
+	it('--loader should load a Preact TSX file but fail because of missing preact package', async () => {
+		const cwd = path.join(import.meta.dirname, 'fixtures/with-preact');
+		const { stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				'--loader',
+				import.meta.resolve('./tsx.mjs'),
+				path.join(cwd, 'main.tsx'),
+			],
+			{
+				cwd,
+			},
+		);
+
+		assert.match(stderr, /Cannot find package 'preact' imported from/);
+		assert.equal(stdout, '');
+	});
+
+	it('--import should load a Preact JSX file but fail because of missing preact package', async () => {
+		const cwd = path.join(import.meta.dirname, 'fixtures/with-preact');
+		const { stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				`--import=${path.join(cwd, 'register.mjs')}`,
+				path.join(cwd, 'main.jsx'),
+			],
+			{
+				cwd,
+			},
+		);
+
+		assert.match(stderr, /Cannot find package 'preact' imported from/);
+		assert.equal(stdout, '');
+	});
+
+	it('--loader should load a SolidJS TSX file but fail because of missing solid-js package', async () => {
+		const cwd = path.join(import.meta.dirname, 'fixtures/with-solid');
+		const { stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				'--loader',
+				import.meta.resolve('./tsx.mjs'),
+				path.join(cwd, 'main.tsx'),
+			],
+			{
+				cwd,
+			},
+		);
+
+		assert.match(stderr, /Cannot find package 'solid-js' imported from/);
+		assert.equal(stdout, '');
+	});
+
+	it('--import should load a SolidJS JSX file but fail because of missing solid-js package', async () => {
+		const cwd = path.join(import.meta.dirname, 'fixtures/with-solid');
+		const { stderr, stdout } = await spawnPromisified(
+			execPath,
+			[
+				'--no-warnings',
+				`--import=${path.join(cwd, 'register.mjs')}`,
+				path.join(cwd, 'main.jsx'),
+			],
+			{
+				cwd,
+			},
+		);
+
+		assert.match(stderr, /Cannot find package 'solid-js' imported from/);
 		assert.equal(stdout, '');
 	});
 });


### PR DESCRIPTION
## Description

Add Preact and SolidJS fixtures/tests for the `tsx` loader, following the existing React test pattern.

This verifies `jsxImportSource` is passed through to esbuild and the emitted runtime imports point to `preact` and `solid-js`.

**Tested with:**

- [x] `PR_TITLE="test(tsx): validate preact and solid jsx runtimes" node --run test`
- [x] `node --run pre-commit`

## Related Issue

Closes #98

## Checklist

The following have been added/updated as appropriate:

- [ ] Documentation, including README(s) and code comments.
- [x] Test-cases.