### PR TITLE
fix(svgx): include now-required import attribute for text

### DIFF
--- a/packages/svgx/svgx.loader.mjs
+++ b/packages/svgx/svgx.loader.mjs
@@ -31,7 +31,11 @@ function loadSVGX(url, ctx, nextLoad) {
 	const name = pascalCase(base);
 
 	return runForAsyncOrSync(
-		nextLoad(url, { ...ctx, format: 'text' }),
+		nextLoad(url, {
+			...ctx,
+			format: 'text',
+			importAttributes: { ...ctx.importAttributes, type: 'text' },
+		}),
 		finaliseLoadSVGX,
 		ctx,
 		name,


### PR DESCRIPTION
Fixes https://github.com/nodejs-loaders/nodejs-loaders/issues/381

This injects the now-required import attribute.